### PR TITLE
Fixes notifications to work with Oreo and older versions of Android

### DIFF
--- a/Exercise 3/Completed/MyDownloader/MyDownloadService.cs
+++ b/Exercise 3/Completed/MyDownloader/MyDownloadService.cs
@@ -9,95 +9,115 @@ using System.Threading.Tasks;
 
 namespace MyDownloader
 {
-    [Service (Label = "MyDownloadService", Icon = "@drawable/Icon") ] 
-    class MyDownloadService : Service
-    {
-        const string tag = "MyDownloadService";
+	[Service(Label = "MyDownloadService", Icon = "@drawable/Icon")]
+	class MyDownloadService : Service
+	{
+		const string tag = "MyDownloadService";
 
-        const int NotificationID = 10000;
-        
+		const int NotificationID = 10000;
+
 		volatile bool isCancelled;
-        volatile bool isDownloaded;
-        
-        PendingIntent pendingIntent;
+		volatile bool isDownloaded;
 
-        public override void OnCreate()
-        {
-            base.OnCreate();
-            Log.Debug(tag, "Service created");
-			
+		PendingIntent pendingIntent;
+
+		public override void OnCreate()
+		{
+			base.OnCreate();
+			Log.Debug(tag, "Service created");
+
 			pendingIntent = PendingIntent.GetActivity(this, 0, new Intent(this, typeof(MainActivity)), 0);
-        }
+		}
 
-        public override IBinder OnBind(Intent intent)
-        {
-            Log.Debug(tag, "OnBind called");
+		public override IBinder OnBind(Intent intent)
+		{
+			Log.Debug(tag, "OnBind called");
 
-            throw new NotImplementedException();
-        }
+			throw new NotImplementedException();
+		}
 
-        public override StartCommandResult OnStartCommand(Intent intent, StartCommandFlags flags, int startId)
-        {
-            Log.Debug(tag, "OnStartCommand called");
-			
+		public override StartCommandResult OnStartCommand(Intent intent, StartCommandFlags flags, int startId)
+		{
+			Log.Debug(tag, "OnStartCommand called");
+
 			StartForeground(NotificationID, GetNotification("Download started"));
-			
+
 			isDownloaded = false;
-            isCancelled = false;
+			isCancelled = false;
 
-            Toast.MakeText(this, "Download Started", ToastLength.Short).Show();
+			Toast.MakeText(this, "Download Started", ToastLength.Short).Show();
 
-            var steps = intent.GetIntExtra("LoopCount", 10);
+			var steps = intent.GetIntExtra("LoopCount", 10);
 
-            Task.Run(() =>
-            {
-                for (int i = 0; i < steps && isCancelled == false; i++)
-                {
-                    int percent = 100 * (i + 1) / steps;
-                    var msg = String.Format("[{0}] download in progress: {1}% complete", startId, percent);
-                    Log.Debug(tag, msg);
-                    UpdateNotification(msg);
+			Task.Run(() =>
+			{
+				for (int i = 0; i < steps && isCancelled == false; i++)
+				{
+					int percent = 100 * (i + 1) / steps;
+					var msg = String.Format("[{0}] download in progress: {1}% complete", startId, percent);
+					Log.Debug(tag, msg);
+					UpdateNotification(msg);
 
-                    Thread.Sleep(500);
-                }
+					Thread.Sleep(500);
+				}
 
-                if (isCancelled == false)
-                {
-                    isDownloaded = true;
-                    StopSelf();
-                }
-            });
+				if (isCancelled == false)
+				{
+					isDownloaded = true;
+					StopSelf();
+				}
+			});
 
-            return StartCommandResult.RedeliverIntent;
-        }
+			return StartCommandResult.RedeliverIntent;
+		}
 
-        void UpdateNotification(string content)
-        {
-            var notification = GetNotification(content);
+		void UpdateNotification(string content)
+		{
+			var notification = GetNotification(content);
 
-            NotificationManager notificationManager = (NotificationManager)GetSystemService(Context.NotificationService);
-            notificationManager.Notify(NotificationID, notification);
-        }
+			NotificationManager notificationManager = (NotificationManager)GetSystemService(Context.NotificationService);
+			notificationManager.Notify(NotificationID, notification);
+		}
 
-        Notification GetNotification(string content)
-        {
-            return new Notification.Builder(this)
-                    .SetContentTitle(tag)
-                    .SetContentText(content)
-                    .SetSmallIcon(Resource.Drawable.icon)
-                    .SetContentIntent(pendingIntent).Build();
-        }
+		Notification GetNotification(string content)
+		{
+			// Beginning with API level 26 (Oreo) all notifications must be assigned to a channel (aka: category), otherwise they won't be shown.
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+			{
+				const string notificationChannelId = "DOWNLOAD_CHANNEL";
+				var notificationManager = (NotificationManager)GetSystemService(Context.NotificationService);
+				var notificationChannel = new NotificationChannel(notificationChannelId, "Downloads", NotificationImportance.Default);
+				notificationManager.CreateNotificationChannel(notificationChannel);
 
-        public override void OnDestroy()
-        {
-            isCancelled = true;
+				return new Notification.Builder(this, notificationChannelId)
+				.SetContentTitle(tag)
+				.SetContentText(content)
+				.SetSmallIcon(Resource.Drawable.icon)
+				.SetContentIntent(pendingIntent)
+				.Build();
+			}
+			else
+			{
+				// Running on a device older than Oreo.
+				return new Notification.Builder(this)
+				.SetContentTitle(tag)
+				.SetContentText(content)
+				.SetSmallIcon(Resource.Drawable.icon)
+				.SetContentIntent(pendingIntent)
+				.Build();
+			}
+		}
 
-            if (isDownloaded)
-                Toast.MakeText(this, "Download Complete", ToastLength.Long).Show();
-            else
-                Toast.MakeText(this, "Download Cancelled", ToastLength.Long).Show();
+		public override void OnDestroy()
+		{
+			isCancelled = true;
 
-            Log.Debug(tag, "Service destroyed");
-        }
-    }
+			if (isDownloaded)
+				Toast.MakeText(this, "Download Complete", ToastLength.Long).Show();
+			else
+				Toast.MakeText(this, "Download Cancelled", ToastLength.Long).Show();
+
+			Log.Debug(tag, "Service destroyed");
+		}
+	}
 }


### PR DESCRIPTION
Oreo requires a notification channel (aka: category) to be defined when creating a notification, otherwise the notification won't be shown and an error will be logged. Older versions of Android don't have to required API methods and need therefore extra treatment. 
